### PR TITLE
Maven 사용자에게 jar이 배포되지 않는 문제 — POM packaging이 pom으로 생성됨

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ v2.0은 메이저 업그레이드입니다. 호출 문법은 대부분 그대로
 
 ## 설치
 
+> 아래 예제의 버전은 작성 시점 기준입니다. **실제 최신 버전은 이 문서 맨 위의 "최신 버전"** 을 확인하세요.
+> 릴리스마다 자동으로 갱신되는 건 그 배너이고, 아래 예제 숫자는 수동 관리라 뒤처져 있을 수 있습니다.
+
 ### Gradle
 
 ```gradle
 dependencies {
-    implementation 'kr.suhsaechan:suh-aider:2.0.0'
+    implementation 'kr.suhsaechan:suh-aider:2.0.2'
 }
 ```
 
@@ -109,7 +112,7 @@ dependencies {
 <dependency>
     <groupId>kr.suhsaechan</groupId>
     <artifactId>suh-aider</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,17 @@ tasks.register('integrationTest', Test) {
 	shouldRunAfter tasks.named('test')
 }
 
+// 이 프로젝트는 실행 가능한 앱이 아니라 라이브러리이므로 bootJar를 끈다.
 bootJar { enabled = false }
-jar { enabled = true }
+
+jar {
+	enabled = true
+	// Spring Boot 플러그인은 bootJar와 구분하려고 일반 jar에 'plain' 분류자를 붙인다.
+	// 분류자가 붙으면 메인 아티팩트가 없는 것으로 취급되어 POM packaging이 'pom'이 되고,
+	// Maven 사용자가 의존성을 걸어도 실제 코드가 딸려오지 않는다.
+	// bootJar를 끈 이상 이름이 충돌할 일이 없으므로 분류자를 제거한다.
+	archiveClassifier = ''
+}
 
 publishing {
 	publications {
@@ -76,7 +85,7 @@ publishing {
 			pom {
 				name = 'suh-aider'
 				description = '서새찬 AI 서버 통신 라이브러리'
-				url = 'https://github.com/Cassiiopeia/suh-aider/'
+				url = 'https://github.com/Cassiiopeia/SUH-AIder'
 			}
 		}
 	}


### PR DESCRIPTION
- https://github.com/Cassiiopeia/SUH-AIder/issues/33

## 요약

Nexus에 배포된 라이브러리를 **Maven 사용자가 쓸 수 없던 문제**를 고칩니다.
v1.x부터 계속 있던 문제이며 이번 릴리스의 회귀는 아닙니다.

## 문제

Spring Boot Gradle 플러그인은 `bootJar`와 이름이 겹치지 않도록 일반 `jar`에 `plain` 분류자를
자동으로 붙입니다. 분류자가 붙으면 Gradle이 "메인 아티팩트 없음"으로 판단해
POM `packaging`을 `jar`가 아닌 `pom`으로 생성합니다.

```
suh-aider-2.0.1-plain.jar    ✅ 존재
suh-aider-2.0.1.pom          ✅ 존재  →  <packaging>pom</packaging>
suh-aider-2.0.1.jar          ❌ 없음
```

| 빌드 도구 | 상태 | 이유 |
|---|---|---|
| Gradle | 정상 | `.module`이 `-plain.jar`을 가리켜 해석됨 |
| **Maven** | **실패** | `.module`을 안 읽고 POM만 봄 → jar를 못 받음 |

README에는 Maven 설치법이 안내돼 있는데 실제로는 동작하지 않았습니다.

## 수정

`bootJar`를 이미 끈 상태라 이름 충돌이 없으므로 분류자를 비웠습니다.

```gradle
bootJar { enabled = false }

jar {
    enabled = true
    archiveClassifier = ''   // 'plain' 제거 → 메인 아티팩트로 인식
}
```

**검증** (`publishToMavenLocal`):

```
수정 전                          수정 후
suh-aider-2.0.1-plain.jar   →   suh-aider-2.0.1.jar        ✅ 클래스 93개 + 자동설정 imports 포함
<packaging>pom</packaging>  →   packaging 기본값(jar)      ✅
```

## 함께 고친 것

**README가 존재하지 않는 버전을 안내하던 문제**

설치 예제가 `2.0.0`을 가리켰는데 Nexus 등록 버전은 `0.2.1, 0.2.3, 1.0.1, 1.1.1, 1.1.2, 2.0.1`로
`2.0.0`이 없습니다. main push 시 버전이 자동 증가해 2.0.0 → 2.0.1로 배포됐기 때문입니다.

README 상단 "최신 버전" 배너는 워크플로가 자동 갱신하지만 설치 예제 안의 숫자는 갱신 대상이
아니라 릴리스마다 어긋납니다. 버전을 정정하고, 최신 버전은 상단 배너를 확인하라는 안내를 덧붙였습니다.

**POM 저장소 URL 정정** — `Cassiiopeia/suh-aider` → `Cassiiopeia/SUH-AIder`

## 검증 결과

- `./gradlew clean build` 성공
- 유닛 테스트 86/86 통과
- `publishToMavenLocal`로 jar 파일명·POM packaging·jar 내용(클래스 93개) 확인
